### PR TITLE
Generate CPU Table (Working on my 13th gen)

### DIFF
--- a/CPU Table Examples/Generate CPU Table.ps1
+++ b/CPU Table Examples/Generate CPU Table.ps1
@@ -1,0 +1,56 @@
+# PowerShell script for generating a CPU Affinity table
+# Can be pasted directly in PowerShell, instead of having to do a .ps1
+
+# Get CPU Information
+$cpuInfo = Get-WmiObject -Class Win32_Processor
+$totalCores = $cpuInfo.NumberOfCores
+$totalThreads = $cpuInfo.NumberOfLogicalProcessors
+
+# Header
+$outputBuilder = New-Object System.Text.StringBuilder
+$outputBuilder.AppendLine(":: Affinity table for $cpuModel with Hyperthreading")
+
+# Function to format BitMask
+Function Format-BitMask ($affinityValue) {
+    $bitMask = [Convert]::ToString($affinityValue, 2)
+    # Ensure a minimum of 8 digits
+    $formattedBitMask = $bitMask.PadLeft(8, '0')
+
+    # Insert space before the last 8 characters
+    if ($formattedBitMask.Length -gt 8) {
+        $formattedBitMask = $formattedBitMask.Insert($formattedBitMask.Length - 8, ' ')
+    }
+
+    return $formattedBitMask
+}
+
+# Calculate the maximum length for Thread ID and Core Type
+$maxCoreTypeLength = "E-Core".Length
+$maxThreadIDLength = ($totalCores - 1).ToString().Length
+
+# Adding Header for the table
+$headerThread = "Thread #".PadRight($maxCoreTypeLength + 1 + $maxThreadIDLength)
+$headerValue = "Value".PadRight(8)
+$outputBuilder.AppendLine(":: $headerThread = $headerValue = BitMask")
+
+# Generate table
+for ($i = 0; $i -lt $totalThreads; $i++) {
+    $affinityValue = 1 -shl $i
+    $formattedBitMask = Format-BitMask -affinityValue $affinityValue
+    
+    # Core Type and ID
+    $coreType = if ($i -lt $totalCores) { "P-Core" } else { "E-Core" }
+    
+    # Format and pad value for right alignment
+    $valuePadded = $affinityValue.ToString().PadRight(8)
+
+    # Format and pad thread ID for alignment
+    $threadID = "$coreType $i"
+    $threadIDPadded = $threadID.PadRight($maxCoreTypeLength + 1 + $maxThreadIDLength)
+
+    # Accumulate Output
+    $outputBuilder.AppendLine(":: $threadIDPadded = $valuePadded = $formattedBitMask")
+}
+
+# Print accumulated output
+$outputBuilder.ToString()


### PR DESCRIPTION
The formatting seems to be correct on my CPU at least. However, I'm not sure where to check the affinity for audiodg on my system since I have just installed VB audio cable to give it a try again (after years of not using) and noticed this project potentially solves crackling. I'm not knowledgeable about it this whole solution but I wanted to contribute something back in case others would benefit. 

Heres what my output looked like.
:: Affinity table for 13th Gen Intel(R) Core(TM) i7-13700K with Hyperthreading
:: Thread #  = Value    = BitMask
:: P-Core 0  = 1        = 00000001
:: P-Core 1  = 2        = 00000010
:: P-Core 2  = 4        = 00000100
:: P-Core 3  = 8        = 00001000
:: P-Core 4  = 16       = 00010000
:: P-Core 5  = 32       = 00100000
:: P-Core 6  = 64       = 01000000
:: P-Core 7  = 128      = 10000000
:: P-Core 8  = 256      = 1 00000000
:: P-Core 9  = 512      = 10 00000000
:: P-Core 10 = 1024     = 100 00000000
:: P-Core 11 = 2048     = 1000 00000000
:: P-Core 12 = 4096     = 10000 00000000
:: P-Core 13 = 8192     = 100000 00000000
:: P-Core 14 = 16384    = 1000000 00000000
:: P-Core 15 = 32768    = 10000000 00000000
:: E-Core 16 = 65536    = 100000000 00000000
:: E-Core 17 = 131072   = 1000000000 00000000
:: E-Core 18 = 262144   = 10000000000 00000000
:: E-Core 19 = 524288   = 100000000000 00000000
:: E-Core 20 = 1048576  = 1000000000000 00000000
:: E-Core 21 = 2097152  = 10000000000000 00000000
:: E-Core 22 = 4194304  = 100000000000000 00000000
:: E-Core 23 = 8388608  = 1000000000000000 00000000